### PR TITLE
Guard null property access

### DIFF
--- a/lib/src/fwupd_client.dart
+++ b/lib/src/fwupd_client.dart
@@ -105,18 +105,18 @@ class FwupdClient {
 
   /// The version of the fwupd daemon.
   String get daemonVersion =>
-      (_properties['DaemonVersion'] as DBusString).value;
+      (_properties['DaemonVersion'] as DBusString?)?.value ?? '';
 
   /// The status of the fwupd daemon.
   FwupdStatus get status {
-    var value = (_properties['Status'] as DBusUint32).value;
-    return value < FwupdStatus.values.length
+    var value = (_properties['Status'] as DBusUint32?)?.value;
+    return value != null && value < FwupdStatus.values.length
         ? FwupdStatus.values[value]
         : FwupdStatus.unknown;
   }
 
   /// The percentage of the current job in process.
-  int get percentage => (_properties['Percentage'] as DBusUint32).value;
+  int get percentage => (_properties['Percentage'] as DBusUint32?)?.value ?? 0;
 
   /// Stream of property names as they change.
   Stream<List<String>> get propertiesChanged =>


### PR DESCRIPTION
The properties are not immediately available so a UI frontend may easily end up querying them "too soon" at construction time.