### PR TITLE
Add fromProperties() factory constructors

### DIFF
--- a/lib/src/fwupd_plugin.dart
+++ b/lib/src/fwupd_plugin.dart
@@ -1,9 +1,15 @@
+import 'package:dbus/dbus.dart';
+
 class FwupdPlugin {
   final String name;
 
   FwupdPlugin({
     required this.name,
   });
+
+  factory FwupdPlugin.fromProperties(Map<String, DBusValue> properties) {
+    return FwupdPlugin(name: (properties['Name'] as DBusString?)?.value ?? '');
+  }
 
   @override
   String toString() => 'FwupdDevice(name: $name)';

--- a/lib/src/fwupd_release.dart
+++ b/lib/src/fwupd_release.dart
@@ -1,5 +1,8 @@
 import 'package:collection/collection.dart';
+import 'package:dbus/dbus.dart';
 import 'package:meta/meta.dart';
+
+import 'fwupd_utils.dart';
 
 enum FwupdReleaseFlag {
   trustedPayload,
@@ -55,6 +58,42 @@ class FwupdRelease {
       this.uri,
       this.vendor = '',
       this.version = ''});
+
+  factory FwupdRelease.fromProperties(Map<String, DBusValue> properties) {
+    var flagsValue = (properties['TrustFlags'] as DBusUint64?)?.value ?? 0;
+    var flags = <FwupdReleaseFlag>{};
+    for (var i = 0; i < FwupdReleaseFlag.values.length; i++) {
+      if (flagsValue & (1 << i) != 0) {
+        flags.add(FwupdReleaseFlag.values[i]);
+      }
+    }
+    var urgencyValue = (properties['Urgency'] as DBusUint32?)?.value ?? 0;
+    var urgency = urgencyValue < FwupdReleaseUrgency.values.length
+        ? FwupdReleaseUrgency.values[urgencyValue]
+        : FwupdReleaseUrgency.unknown;
+    return FwupdRelease(
+        appstreamId: (properties['AppstreamId'] as DBusString?)?.value,
+        checksum: (properties['Checksum'] as DBusString?)?.value,
+        created: properties['Created']?.toDateTime(),
+        description: (properties['Description'] as DBusString?)?.value ?? '',
+        filename: (properties['Filename'] as DBusString?)?.value,
+        homepage: (properties['Homepage'] as DBusString?)?.value ?? '',
+        installDuration:
+            (properties['InstallDuration'] as DBusUint32?)?.value ?? 0,
+        license: (properties['License'] as DBusString?)?.value ?? '',
+        locations:
+            (properties['Locations'] as DBusArray?)?.mapString().toList() ?? [],
+        name: (properties['Name'] as DBusString?)?.value ?? '',
+        protocol: (properties['Protocol'] as DBusString?)?.value,
+        remoteId: (properties['RemoteId'] as DBusString?)?.value,
+        size: (properties['Size'] as DBusUint64?)?.value ?? 0,
+        summary: (properties['Summary'] as DBusString?)?.value ?? '',
+        flags: flags,
+        urgency: urgency,
+        uri: (properties['Uri'] as DBusString?)?.value,
+        vendor: (properties['Vendor'] as DBusString?)?.value ?? '',
+        version: (properties['Version'] as DBusString?)?.value ?? '');
+  }
 
   @override
   String toString() =>

--- a/lib/src/fwupd_remote.dart
+++ b/lib/src/fwupd_remote.dart
@@ -1,4 +1,9 @@
+import 'package:dbus/dbus.dart';
+
+import 'fwupd_utils.dart';
+
 enum FwupdRemoteKind { unknown, download, local, directory }
+
 enum FwupdKeyringKind { unknown, none, gpg, pkcs7, jcat }
 
 class FwupdRemote {
@@ -48,6 +53,46 @@ class FwupdRemote {
       this.securityReportUri,
       this.title,
       this.username});
+
+  factory FwupdRemote.fromProperties(Map<String, DBusValue> properties) {
+    var kindValue = (properties['Type'] as DBusUint32?)?.value ?? 0;
+    var kind = kindValue < FwupdRemoteKind.values.length
+        ? FwupdRemoteKind.values[kindValue]
+        : FwupdRemoteKind.unknown;
+    var keyringValue = (properties['Keyring'] as DBusUint32?)?.value ?? 0;
+    var keyring = keyringValue < FwupdKeyringKind.values.length
+        ? FwupdKeyringKind.values[keyringValue]
+        : FwupdKeyringKind.jcat;
+    return FwupdRemote(
+      age: properties['ModificationTime']?.toDateTime(),
+      agreement: (properties['Agreement'] as DBusString?)?.value,
+      approvalRequired:
+          (properties['ApprovalRequired'] as DBusBoolean?)?.value ?? false,
+      automaticReports:
+          (properties['AutomaticReports'] as DBusBoolean?)?.value ?? false,
+      automaticSecurityReports:
+          (properties['AutomaticSecurityReports'] as DBusBoolean?)?.value ??
+              false,
+      checksum: (properties['Checksum'] as DBusString?)?.value,
+      enabled: (properties['Enabled'] as DBusBoolean?)?.value ?? false,
+      filenameCache: (properties['FilenameCache'] as DBusString?)?.value,
+      filenameCacheSig: (properties['FilenameCacheSig'] as DBusString?)?.value,
+      filenameSource: (properties['FilenameSource'] as DBusString?)?.value,
+      firmwareBaseUri: (properties['FirmwareBaseUri'] as DBusString?)?.value,
+      id: (properties['RemoteId'] as DBusString?)?.value ?? '',
+      keyringKind: keyring,
+      kind: kind,
+      metadataUri: (properties['Uri'] as DBusString?)?.value,
+      password: (properties['Password'] as DBusString?)?.value,
+      priority: (properties['Priority'] as DBusInt32?)?.value ?? 0,
+      remotesDir: (properties['RemotesDir'] as DBusString?)?.value,
+      reportUri: (properties['ReportUri'] as DBusString?)?.value,
+      securityReportUri:
+          (properties['SecurityReportUri'] as DBusString?)?.value,
+      title: (properties['Title'] as DBusString?)?.value,
+      username: (properties['Username'] as DBusString?)?.value,
+    );
+  }
 
   @override
   String toString() =>

--- a/lib/src/fwupd_utils.dart
+++ b/lib/src/fwupd_utils.dart
@@ -1,0 +1,12 @@
+import 'package:dbus/dbus.dart';
+
+extension FwupdTimestamp on DBusValue {
+  DateTime? toDateTime() {
+    if (this is! DBusUint64) return null;
+    var secs = (this as DBusUint64).value;
+    if (secs <= 0) {
+      return null;
+    }
+    return DateTime.fromMillisecondsSinceEpoch(secs * 1000, isUtc: true);
+  }
+}


### PR DESCRIPTION
Further trims down the size of `fwupd_client.dart` by moving property parsing logic together with the respective data types. This proposal was inspired by the `fromJson()` convention commonly used in Dart.