### PR TITLE
CI: use flutter_tools for collecting coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,24 @@ jobs:
         run: dart pub get
 
       - name: Run regression tests
-        run: dart run test_cov
+        run: dart test
+
+  coverage:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: subosito/flutter-action@v2
+
+      - name: Print Flutter SDK version
+        run: flutter --version
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Collect coverage
+        run: flutter test --coverage
 
       - name: Upload coverage
         uses: codecov/codecov-action@v1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,4 +20,3 @@ dependencies:
 dev_dependencies:
   lints: ^1.0.1
   test: ^1.16.8
-  test_cov: ^1.0.1


### PR DESCRIPTION
Same change as canonical/dbus.dart#337 but because of different
`test_cov` breakage. It doesn't work with the latest stable Dart SDK
SDK version 2.17. It throws an exception in the CI, and hangs locally.

https://github.com/canonical/fwupd.dart/runs/6398669148

NOTE: this will only use Flutter tooling for collecting test coverage
in the CI without introducing an actual dependency to the Flutter SDK
on the package level.